### PR TITLE
fix to run on remote host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     build: ./ui
     restart: always
     environment:
-      - REACT_APP_URL=${APP_URL:-http://localhost}
       - NODE_ENV=${NODE_ENV:-production}
   track-and-trace-nginx:
     depends_on:

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -1,7 +1,7 @@
 export const apiUrl =
   process.env.REACT_APP_URL
     ? process.env.REACT_APP_URL + '/api/v1'
-    : 'http://localhost/api/v1';
+    : '/api/v1';
 
 export const HTTP_METHODS = {
   GET: 'GET',


### PR DESCRIPTION
when running on remote host, the APP_URL (REACT_APP_URL) provided from docker-compose.yml to ui server did nothing at all. This change fixes the default value to be more multipurpose