### PR TITLE
strato 4.5 compatibility - new strato docker network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,4 @@ services:
 networks:
   default:
     external:
-      name: strato_default
+      name: strato_static


### PR DESCRIPTION
to be merged once the STRATO 4.5 released.
The only option for backwards-compatibility with older strato versions would be to add the preflight script to prepopulate the network name (strato_default or strato_static) in docker-compose.yml
But this seems to be an overcomplication for me as currently we just start t&t with `docker-compose up`